### PR TITLE
Updated files for release 1.1.20(2)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 k2hash (1.1.20) unstable; urgency=low
 
+  * Fixed a bug in nodejs_helper.sh - #15
   * Switched Travis CI to Github actions - #13
   * Supported Node.js 12 and 14 - #12
   * Fixed wrong package name in ChangeLog - #11


### PR DESCRIPTION
## Relevant Issue (if applicable)
#14 

## Details
### Changes from 1.1.19 to 1.1.20
- Fixed a bug in nodejs_helper.sh - #15
- Switched Travis CI to Github actions - #13
- Supported Node.js 12 and 14 - #12
- Fixed wrong package name in ChangeLog - #11 
