### PR TITLE
Updated support NodeJS version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [18, 20]
 
     steps:
       #

--- a/.github/workflows/nodejstypevars.sh
+++ b/.github/workflows/nodejstypevars.sh
@@ -80,6 +80,12 @@ elif [ "${CI_NODEJS_MAJOR_VERSION}" = "18" ]; then
 	INSTALLER_BIN="apt-get"
 	INSTALL_QUIET_ARG="-qq"
 	IS_PUBLISHER=1
+
+elif [ "${CI_NODEJS_MAJOR_VERSION}" = "20" ]; then
+	INSTALL_PKG_LIST="git gcc g++ make k2hash-dev"
+	INSTALLER_BIN="apt-get"
+	INSTALL_QUIET_ARG="-qq"
+	IS_PUBLISHER=0
 fi
 
 #---------------------------------------------------------------


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
Changed NodeJS versions supported by Github Actions CI to 18 and 20.
