### PR TITLE
Changed the cppcheck std version options, etc

### DIFF
--- a/.github/workflows/nodejs_addon_helper.sh
+++ b/.github/workflows/nodejs_addon_helper.sh
@@ -1370,7 +1370,7 @@ PRNSUCCESS "Start to check options and environments"
 # Default command parameters for each phase
 #
 CPPCHECK_TARGET="."
-CPPCHECK_BASE_OPT="--quiet --error-exitcode=1 --inline-suppr -j 8 --std=c++14 --xml --enable=warning,style,information,missingInclude"
+CPPCHECK_BASE_OPT="--quiet --error-exitcode=1 --inline-suppr -j 8 --std=c++17 --xml --enable=warning,style,information,missingInclude"
 CPPCHECK_ENABLE_VALUES="warning style information missingInclude"
 CPPCHECK_IGNORE_VALUES="unmatchedSuppression missingIncludeSystem normalCheckLevelMaxBranches"
 CPPCHECK_BUILD_DIR="/tmp/cppcheck"

--- a/.github/workflows/nodejstypevars.sh
+++ b/.github/workflows/nodejstypevars.sh
@@ -433,7 +433,7 @@ fi
 # Each value has a default value for NodeJS processing.
 #
 #	CPPCHECK_TARGET					"."
-#	CPPCHECK_BASE_OPT				"--quiet --error-exitcode=1 --inline-suppr -j 4 --std=c++03 --xml"
+#	CPPCHECK_BASE_OPT				"--quiet --error-exitcode=1 --inline-suppr -j 4 --std=c++17 --xml"
 #	CPPCHECK_ENABLE_VALUES			"warning style information missingInclude"
 #	CPPCHECK_IGNORE_VALUES			"unmatchedSuppression missingIncludeSystem normalCheckLevelMaxBranches"
 #	CPPCHECK_BUILD_DIR				"/tmp/cppcheck"

--- a/buildutils/make_node_prebuild_variables.sh
+++ b/buildutils/make_node_prebuild_variables.sh
@@ -1,16 +1,18 @@
 #!/bin/sh
 #
-# K2HASH
+# Utility helper tools for Github Actions by AntPickax
 #
-# Copyright 2015 Yahoo Japan Corporation.
+# Copyright 2025 Yahoo Japan Corporation.
 #
-# K2HASH is key-valuew store base libraries.
-# K2HASH is made for the purpose of the construction of
-# original KVS system and the offer of the library.
-# The characteristic is this KVS library which Key can
-# layer. And can support multi-processing and multi-thread,
-# and is provided safely as available KVS.
+# AntPickax provides utility tools for supporting nodejs addon.
 #
+# These tools retrieve the necessary information from the
+# repository and appropriately set the setting values of
+# configure, Makefile, spec,etc file and so on.
+# These tools were recreated to reduce the number of fixes and
+# reduce the workload of developers when there is a change in
+# the project configuration.
+# 
 # For the full copyright and license information, please view
 # the license file that was distributed with this source code.
 #

--- a/buildutils/node_prebuild.sh
+++ b/buildutils/node_prebuild.sh
@@ -1,16 +1,18 @@
 #!/bin/sh
 #
-# K2HASH
+# Utility helper tools for Github Actions by AntPickax
 #
-# Copyright 2015 Yahoo Japan Corporation.
+# Copyright 2025 Yahoo Japan Corporation.
 #
-# K2HASH is key-valuew store base libraries.
-# K2HASH is made for the purpose of the construction of
-# original KVS system and the offer of the library.
-# The characteristic is this KVS library which Key can
-# layer. And can support multi-processing and multi-thread,
-# and is provided safely as available KVS.
+# AntPickax provides utility tools for supporting nodejs addon.
 #
+# These tools retrieve the necessary information from the
+# repository and appropriately set the setting values of
+# configure, Makefile, spec,etc file and so on.
+# These tools were recreated to reduce the number of fixes and
+# reduce the workload of developers when there is a change in
+# the project configuration.
+# 
 # For the full copyright and license information, please view
 # the license file that was distributed with this source code.
 #

--- a/buildutils/node_prebuild_install.sh
+++ b/buildutils/node_prebuild_install.sh
@@ -1,16 +1,18 @@
 #!/bin/sh
 #
-# K2HASH
+# Utility helper tools for Github Actions by AntPickax
 #
-# Copyright 2015 Yahoo Japan Corporation.
+# Copyright 2025 Yahoo Japan Corporation.
 #
-# K2HASH is key-valuew store base libraries.
-# K2HASH is made for the purpose of the construction of
-# original KVS system and the offer of the library.
-# The characteristic is this KVS library which Key can
-# layer. And can support multi-processing and multi-thread,
-# and is provided safely as available KVS.
+# AntPickax provides utility tools for supporting nodejs addon.
 #
+# These tools retrieve the necessary information from the
+# repository and appropriately set the setting values of
+# configure, Makefile, spec,etc file and so on.
+# These tools were recreated to reduce the number of fixes and
+# reduce the workload of developers when there is a change in
+# the project configuration.
+# 
 # For the full copyright and license information, please view
 # the license file that was distributed with this source code.
 #

--- a/src/k2hash.cc
+++ b/src/k2hash.cc
@@ -38,7 +38,7 @@ Napi::Value CreateObject(const Napi::CallbackInfo& info)
 Napi::Object InitAll(Napi::Env env, Napi::Object exports)
 {
 	// Class registration (creating a constructor)
-	K2hNode::Init(env, exports); // この中で constructor を作って Persistent に保存している想定
+	K2hNode::Init(env, exports);
 
 	// Create a factory function that returns module.exports
 	Napi::Function createFn = Napi::Function::New(env, CreateObject, "k2hash");


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
Since N-API requires C++17 or later, the value of the cppcheck `--std` option has been changed to `c++17` accordingly.
And we also made some minor corrections to comments.
