### PR TITLE
Added type aliases and exports for Typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
   "license": "MIT",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./index.mjs",
       "require": "./index.js"
     }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -558,6 +558,9 @@ declare module 'k2hash'
 	export type K2hQueue			= k2hash.K2hQueue;
 	export type K2hKeyQueue			= k2hash.K2hKeyQueue;
 	export type K2hashFactoryType	= k2hash.K2hashFactoryType;
+
+	// Add convenient alias (PascalCase)
+	export type K2hash				= K2hNode;
 }
 
 /*


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
To improve convenience when using Typescript, we have added K2hash as a type alias for Typescript.
And also added a types item to exports.
